### PR TITLE
Support for $css, $visible, $hidden assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@ npm-debug\.log
 .testem-dev.tap
 .testem-ci.tap
 
+\.idea
+*.iml
+
 local

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 History
 =======
 
+## 0.0.2
+
+* Extension of API with: `$css`, `$visible`, `$hidden`.
+
 ## 0.0.1
 
 * Initial release with API: `$val`, `$class`, `$attr`, `$prop`, `$html`,

--- a/README.md
+++ b/README.md
@@ -44,6 +44,28 @@ expect($("<div class='foo bar' />"))
 
 See: [http://api.jquery.com/hasClass/]()
 
+### `.$visible`
+
+Asserts that the element is visible.
+
+```js
+expect($("<div>&nbsp;</div>"))
+  .to.be.$visible;
+```
+
+See: [http://api.jquery.com/visible-selector/]()
+
+### `.$hidden`
+
+Asserts that the element is hidden.
+
+```js
+expect($("<div style=\"display: none\" />"))
+  .to.be.$hidden;
+```
+
+See: [http://api.jquery.com/hidden-selector/]()
+
 ### `.$attr(name, string)`
 
 Asserts that the target has exactly the given named attribute, or
@@ -51,7 +73,7 @@ asserts the target contains a subset of the attribute when using the
 `include` or `contain` modifiers.
 
 ```js
-expect($("<div id=\"hi\" foo=\"bar time\">/div>"))
+expect($("<div id=\"hi\" foo=\"bar time\"></div>"))
   .to.have.$attr("id", "hi").and
   .to.contain.$attr("foo", "bar");
 ```
@@ -97,6 +119,18 @@ expect($("<div><span>foo</span> bar</div>"))
 ```
 
 See: [http://api.jquery.com/text/]()
+
+### `.$css(name, string)`
+
+Asserts that the target has exactly the given CSS property.
+
+```js
+expect($("<div style=\"width: 50px; border: 1px dotted black;\"></div>"))
+  .to.have.$css("width", "50px").and
+  .to.have.$css("border-top-style", "dotted");
+```
+
+See: [http://api.jquery.com/css/]()
 
 ## Contributions
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,6 @@ Tasks
 
 * `all`: Flag to apply to **each** element in selector match.
 * `some`: Flag to apply to **at least one** element in selector match.
-* `css`: http://api.jquery.com/css/
 
 ## Environments
 

--- a/chai-jq.js
+++ b/chai-jq.js
@@ -154,6 +154,64 @@
     chai.Assertion.addMethod("$class", $class);
 
     /*!
+     * Base for the boolean is("selector") method call.
+     *
+     *
+     * See: [http://api.jquery.com/is/]
+     *
+     * @param {String} selector jQuery selector to match against
+     */
+    var _isMethod = function (jqSelector) {
+      // Return decorated assert.
+      return _jqAssert(function () {
+        // Make it human readable
+        var selectorDesc = jqSelector.replace(/:/g, "");
+
+        this.assert(
+          this._$el.is(jqSelector),
+          "expected " + this._name + " to be " + selectorDesc,
+          "expected " + this._name + " to not be " + selectorDesc
+        );
+      });
+    };
+
+    /**
+     * `.$visible`
+     *
+     * Asserts that the element is visible.
+     *
+     * ```js
+     * expect($("<div>&nbsp;</div>"))
+     *   .to.be.$visible;
+     * ```
+     *
+     * See: [http://api.jquery.com/visible-selector/]()
+     *
+     * @api public
+     */
+    var $visible = _isMethod(":visible");
+
+    chai.Assertion.addProperty("$visible", $visible);
+
+    /**
+     * `.$hidden`
+     *
+     * Asserts that the element is hidden.
+     *
+     * ```js
+     * expect($("<div style=\"display: none\" />"))
+     *   .to.be.$hidden;
+     * ```
+     *
+     * See: [http://api.jquery.com/hidden-selector/]()
+     *
+     * @api public
+     */
+    var $hidden = _isMethod(":hidden");
+
+    chai.Assertion.addProperty("$hidden", $hidden);
+
+    /*!
      * Abstract base for a "containable" method call.
      *
      * @param {String} jQuery           method name.
@@ -207,7 +265,7 @@
      * `include` or `contain` modifiers.
      *
      * ```js
-     * expect($("<div id=\"hi\" foo=\"bar time\">/div>"))
+     * expect($("<div id=\"hi\" foo=\"bar time\"></div>"))
      *   .to.have.$attr("id", "hi").and
      *   .to.contain.$attr("foo", "bar");
      * ```
@@ -301,6 +359,30 @@
     });
 
     chai.Assertion.addMethod("$text", $text);
+
+    /**
+     * `.$css(name, string)`
+     *
+     * Asserts that the target has exactly the given CSS property.
+     *
+     * ```js
+     * expect($("<div style=\"width: 50px; border: 1px dotted black;\"></div>"))
+     *   .to.have.$css("width", "50px").and
+     *   .to.have.$css("border-top-style", "dotted");
+     * ```
+     *
+     * See: [http://api.jquery.com/css/]()
+     *
+     * @name $css
+     * @param {String} expected CSS property content
+     * @param {String} message _optional_
+     * @api public
+     */
+    var $css = _containMethod("css", {
+      hasArg: true
+    });
+
+    chai.Assertion.addMethod("$css", $css);
   }
 
   /*!

--- a/index.html
+++ b/index.html
@@ -51,11 +51,21 @@ library to provide jQuery-specific assertions.</p>
   .to.have.$class(&quot;foo&quot;).and
   .to.have.$class(&quot;bar&quot;);</code></pre>
 <p>See: <a href=""><a href="http://api.jquery.com/hasClass/">http://api.jquery.com/hasClass/</a></a></p>
+<h3 id="-visible-"><code>.$visible</code></h3>
+<p>Asserts that the element is visible.</p>
+<pre><code class="lang-js">expect($(&quot;&lt;div&gt;&amp;nbsp;&lt;/div&gt;&quot;))
+  .to.be.$visible;</code></pre>
+<p>See: <a href=""><a href="http://api.jquery.com/visible-selector/">http://api.jquery.com/visible-selector/</a></a></p>
+<h3 id="-hidden-"><code>.$hidden</code></h3>
+<p>Asserts that the element is hidden.</p>
+<pre><code class="lang-js">expect($(&quot;&lt;div style=\&quot;display: none\&quot; /&gt;&quot;))
+  .to.be.$hidden;</code></pre>
+<p>See: <a href=""><a href="http://api.jquery.com/hidden-selector/">http://api.jquery.com/hidden-selector/</a></a></p>
 <h3 id="-attr-name-string-"><code>.$attr(name, string)</code></h3>
 <p>Asserts that the target has exactly the given named attribute, or
 asserts the target contains a subset of the attribute when using the
 <code>include</code> or <code>contain</code> modifiers.</p>
-<pre><code class="lang-js">expect($(&quot;&lt;div id=\&quot;hi\&quot; foo=\&quot;bar time\&quot;&gt;/div&gt;&quot;))
+<pre><code class="lang-js">expect($(&quot;&lt;div id=\&quot;hi\&quot; foo=\&quot;bar time\&quot;&gt;&lt;/div&gt;&quot;))
   .to.have.$attr(&quot;id&quot;, &quot;hi&quot;).and
   .to.contain.$attr(&quot;foo&quot;, &quot;bar&quot;);</code></pre>
 <p>See: <a href=""><a href="http://api.jquery.com/attr/">http://api.jquery.com/attr/</a></a></p>
@@ -81,6 +91,12 @@ asserts the target contains a subset of the text when using the
   .to.have.$text(&quot;foo bar&quot;).and
   .to.contain.$text(&quot;foo&quot;);</code></pre>
 <p>See: <a href=""><a href="http://api.jquery.com/text/">http://api.jquery.com/text/</a></a></p>
+<h3 id="-css-name-string-"><code>.$css(name, string)</code></h3>
+<p>Asserts that the target has exactly the given CSS property.</p>
+<pre><code class="lang-js">expect($(&quot;&lt;div style=\&quot;width: 50px; border: 1px dotted black;\&quot;&gt;&lt;/div&gt;&quot;))
+  .to.have.$css(&quot;width&quot;, &quot;50px&quot;).and
+  .to.have.$css(&quot;border-top-style&quot;, &quot;dotted&quot;);</code></pre>
+<p>See: <a href=""><a href="http://api.jquery.com/css/">http://api.jquery.com/css/</a></a></p>
 <h2 id="contributions">Contributions</h2>
 <p>Please see the <a href="./CONTRIBUTING.md">Contributions Guide</a> for how to help out
 with the plugin.</p>
@@ -117,6 +133,10 @@ license.</p>
 
         </div>
         <div id="history"><h1 id="history">History</h1>
+<h2 id="0-0-2">0.0.2</h2>
+<ul>
+<li>Extension of API with: <code>$css</code>, <code>$visible</code>, <code>$hidden</code>.</li>
+</ul>
 <h2 id="0-0-1">0.0.1</h2>
 <ul>
 <li>Initial release with API: <code>$val</code>, <code>$class</code>, <code>$attr</code>, <code>$prop</code>, <code>$html</code>,

--- a/test/js/spec/chai-jq.spec.js
+++ b/test/js/spec/chai-jq.spec.js
@@ -169,8 +169,59 @@ define(["jquery", "chai"], function ($, chai) {
                     "but found 'CLS1 CLS2'");
 
         expect($("<div class='foo bar' />"))
-         .to.have.$class("foo").and
-         .to.have.$class("bar");
+          .to.have.$class("foo").and
+          .to.have.$class("bar");
+      });
+    });
+
+    describe("$visible, $hidden", function () {
+      beforeEach(function () {
+        this.$fixture = $("<div id=\"test\" >&nbsp;</div>")
+          .appendTo(this.$base);
+      });
+
+      it("verifies element visibility", function () {
+        var $fixture = this.$fixture;
+
+        expect($fixture)
+          .to.be.$visible.and
+          .to.not.be.$hidden;
+
+        $fixture.hide();
+
+        expect($fixture)
+          .to.be.$hidden.and
+          .to.not.be.$visible;
+
+        expect(function () {
+          expect($fixture).to.be.$visible;
+        }).to.throw("expected '#test' to be visible");
+
+        $fixture.show();
+
+        expect(function () {
+          expect($fixture).to.be.$hidden;
+        }).to.throw("expected '#test' to be hidden");
+
+        expect($("<div style=\"width: 0; height: 0;\" />"))
+          .to.be.$hidden.and
+          .to.not.be.$visible;
+      });
+
+      it("verifies visibility if parent is hidden", function () {
+        var $fixture = this.$fixture;
+
+        $fixture.wrap("<div />");
+
+        expect($fixture)
+          .to.be.$visible.and
+          .to.not.be.$hidden;
+
+        $fixture.parent().hide();
+
+        expect($fixture)
+          .to.be.$hidden.and
+          .to.not.be.$visible;
       });
     });
 
@@ -338,6 +389,33 @@ define(["jquery", "chai"], function ($, chai) {
         expect($("<div><span>foo</span> bar</div>"))
           .to.have.$text("foo bar").and
           .to.contain.$text("foo");
+      });
+    });
+
+    describe("$css", function () {
+      beforeEach(function () {
+        this.$fixture = $("<div style=\"width: 50px;" +
+          "border: 1px dotted black;\" />").appendTo(this.$base);
+      });
+
+      it("matches CSS property", function () {
+        var $fixture = this.$fixture;
+
+        expect($fixture)
+          .to.have.$css("width", "50px").and
+          .to.have.$css("border-top-style", "dotted").and
+          .to.not
+          .have.$css("width", "100px").and
+          .have.$css("border-top-style", "solid");
+
+        expect(function () {
+          expect($fixture).to.have.$css("width", "100px");
+        }).to.throw("expected [object Object] to have css('width') '100px' " +
+            "but found '50px'");
+
+        expect($("<p style=\"float: left; display: none;\" />"))
+          .to.have.$css("float", "left").and
+          .to.have.$css("display", "none");
       });
     });
 


### PR DESCRIPTION
Usage of new assertions:

``` javascript
expect($el).to.have.$css("width", "50px");
expect($el).to.be.$visible;
expect($el).to.not.be.$hidden;
```
