### PR TITLE
Support for $data assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ value.
 * [`$val(expected, [message])`](#-val-expected-message-)
 * [`$class(expected, [message])`](#-class-expected-message-)
 * [`$attr(name, [expected], [message])`](#-attr-name-expected-message-)
+* [`$data(name, [expected], [message])`](#-data-name-expected-message-)
 * [`$prop(name, [expected], [message])`](#-prop-name-expected-message-)
 * [`$html(expected, [message])`](#-html-expected-message-)
 * [`$text(expected, [message])`](#-text-expected-message-)
@@ -204,6 +205,35 @@ expect($("<div id=\"hi\" foo=\"bar time\" />"))
 ```
 
 See: [http://api.jquery.com/attr/](http://api.jquery.com/attr/)
+
+### `$data(name, [expected], [message])`
+* **name** (`String`) data-attribute name
+* **expected** (`String`) data-attribute content (_optional_)
+* **message** (`String`) failure message (_optional_)
+* **_returns_** current object or attribute string value
+
+Asserts that the target has exactly the given named 
+data-attribute, or asserts the target contains a subset 
+of the data-attribute when using the
+`include` or `contain` modifiers.
+
+```js
+expect($("<div data-id=\"hi\" data-foo=\"bar time\" />"))
+  .to.have.$data("id", "hi").and
+  .to.contain.$data("foo", "bar");
+```
+
+Changes context to data-attribute string *value* when no 
+expected value is provided:
+
+```js
+expect($("<div data-id=\"hi\" data-foo=\"bar time\" />"))
+  .to.have.$data("foo").and
+    .to.equal("bar time").and
+    .to.match(/^b/);
+```
+
+See: [http://api.jquery.com/data/](http://api.jquery.com/data/)
 
 ### `$prop(name, [expected], [message])`
 * **name** (`String`) property name

--- a/chai-jq.js
+++ b/chai-jq.js
@@ -327,6 +327,44 @@
     chai.Assertion.addMethod("$attr", $attr);
 
     /**
+     * Asserts that the target has exactly the given named 
+     * data-attribute, or asserts the target contains a subset 
+     * of the data-attribute when using the
+     * `include` or `contain` modifiers.
+     *
+     * ```js
+     * expect($("<div data-id=\"hi\" data-foo=\"bar time\" />"))
+     *   .to.have.$data("id", "hi").and
+     *   .to.contain.$data("foo", "bar");
+     * ```
+     *
+     * Changes context to data-attribute string *value* when no 
+     * expected value is provided:
+     *
+     * ```js
+     * expect($("<div data-id=\"hi\" data-foo=\"bar time\" />"))
+     *   .to.have.$data("foo").and
+     *     .to.equal("bar time").and
+     *     .to.match(/^b/);
+     * ```
+     *
+     * @see http://api.jquery.com/data/
+     *
+     * @param {String} name     data-attribute name
+     * @param {String} expected data-attribute content (_optional_)
+     * @param {String} message  failure message (_optional_)
+     * @returns current object or attribute string value
+     * @api public
+     */
+    var $data = _containMethod("data", {
+      hasArg: true,
+      hasContains: true,
+      isProperty: true
+    });
+
+    chai.Assertion.addMethod("$data", $data);
+
+    /**
      * Asserts that the target has exactly the given named property.
      *
      * ```js

--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@ value.</p>
 <li><a href="#-val-expected-message-"><code>$val(expected, [message])</code></a></li>
 <li><a href="#-class-expected-message-"><code>$class(expected, [message])</code></a></li>
 <li><a href="#-attr-name-expected-message-"><code>$attr(name, [expected], [message])</code></a></li>
+<li><a href="#-data-name-expected-message-"><code>$data(name, [expected], [message])</code></a></li>
 <li><a href="#-prop-name-expected-message-"><code>$prop(name, [expected], [message])</code></a></li>
 <li><a href="#-html-expected-message-"><code>$html(expected, [message])</code></a></li>
 <li><a href="#-text-expected-message-"><code>$text(expected, [message])</code></a></li>
@@ -168,6 +169,27 @@ provided:</p>
     .to.equal(&quot;bar time&quot;).and
     .to.match(/^b/);</code></pre>
 <p>See: <a href="http://api.jquery.com/attr/"><a href="http://api.jquery.com/attr/">http://api.jquery.com/attr/</a></a></p>
+<h3 id="-data-name-expected-message-"><code>$data(name, [expected], [message])</code></h3>
+<ul>
+<li><strong>name</strong> (<code>String</code>) data-attribute name</li>
+<li><strong>expected</strong> (<code>String</code>) data-attribute content (<em>optional</em>)</li>
+<li><strong>message</strong> (<code>String</code>) failure message (<em>optional</em>)</li>
+<li><strong><em>returns</em></strong> current object or attribute string value</li>
+</ul>
+<p>Asserts that the target has exactly the given named 
+data-attribute, or asserts the target contains a subset 
+of the data-attribute when using the
+<code>include</code> or <code>contain</code> modifiers.</p>
+<pre><code class="lang-js">expect($(&quot;&lt;div data-id=\&quot;hi\&quot; data-foo=\&quot;bar time\&quot; /&gt;&quot;))
+  .to.have.$data(&quot;id&quot;, &quot;hi&quot;).and
+  .to.contain.$data(&quot;foo&quot;, &quot;bar&quot;);</code></pre>
+<p>Changes context to data-attribute string <em>value</em> when no 
+expected value is provided:</p>
+<pre><code class="lang-js">expect($(&quot;&lt;div data-id=\&quot;hi\&quot; data-foo=\&quot;bar time\&quot; /&gt;&quot;))
+  .to.have.$data(&quot;foo&quot;).and
+    .to.equal(&quot;bar time&quot;).and
+    .to.match(/^b/);</code></pre>
+<p>See: <a href="http://api.jquery.com/data/"><a href="http://api.jquery.com/data/">http://api.jquery.com/data/</a></a></p>
 <h3 id="-prop-name-expected-message-"><code>$prop(name, [expected], [message])</code></h3>
 <ul>
 <li><strong>name</strong> (<code>String</code>) property name</li>

--- a/test/js/spec/chai-jq.spec.js
+++ b/test/js/spec/chai-jq.spec.js
@@ -320,6 +320,89 @@ define(["jquery"], function ($) {
           .to.contain.$attr("foo", "bar");
       });
     });
+    
+    describe("$data", function () {
+      beforeEach(function () {
+        var el = "<div id=\"test\" " +
+          "data-id=\"test\" " +
+          "data-options='{\"name\":\"John\"}' " +
+          "data-foo=\"fun time\" />";
+        this.$fixture = $(el)
+          .appendTo(this.$base);
+      });
+
+      it("matches attribute", function () {
+        var $fixture = this.$fixture;
+
+        expect($fixture)
+          .to.have.$data("id", "test").and
+          .to.have.$data("foo", "fun time").and
+          .to.not
+            .have.$data("id", "te").and
+            .have.$data("foo", "time");
+
+        expect($fixture)
+          .to.have.$data("options").and
+          .to.have.property("name", "John");
+
+        expect(function () {
+          expect($fixture).to.have.$data("foo", "fun");
+        }).to.throw("expected '#test' to have data('foo') 'fun' " +
+                    "but found '" + "fun time" + "'");
+      });
+
+      it("checks presence of attribute", function () {
+        var $fixture = this.$fixture;
+
+        expect($fixture).to.have.$data("id");
+        expect($fixture).to.have.$data("foo");
+        expect(this.$fixture).to.not.have.$data("bar");
+
+        expect(function () {
+          expect($fixture).to.have.$data("bar");
+        }).to.throw("expected '#test' to have data('bar')");
+
+        expect(function () {
+          expect($fixture).to.not.have.$data("foo");
+        }).to.throw("expected '#test' not to have data('foo')");
+      });
+
+      it("changes context to attribute", function () {
+        expect(this.$fixture).to.have.$data("foo").and
+          .to.equal("fun time").and
+          .to.match(/^f/).and
+          .to.not.have.length(2);
+      });
+
+      it("does not change context for negated attribute", function () {
+        expect(this.$fixture).to.not
+          .have.$data("bar").and
+          .have.$data("baz").and
+          .have.$data("boy");
+      });
+
+      it("matches attribute subsets", function () {
+        var $fixture = this.$fixture;
+
+        expect($fixture)
+          .to.contain.$data("id", "test").and
+          .to.contain.$data("id", "te").and
+          .to.contain.$data("foo", "fun time").and
+          .to.contain.$data("foo", "fun").and
+          .to.not
+            .contain.$data("id", "ate").and
+            .contain.$data("foo", "atime");
+
+        expect(function () {
+          expect($fixture).to.contain.$data("foo", "funky");
+        }).to.throw("expected '#test' to contain data('foo') 'funky' " +
+                    "but found '" + "fun time" + "'");
+
+        expect($("<div id=\"test\" data-id=\"hi\" data-foo=\"bar time\" />"))
+          .to.have.$data("id", "hi").and
+          .to.contain.$data("foo", "bar");
+      });
+    });
 
     describe("$prop", function () {
       beforeEach(function () {


### PR DESCRIPTION
Usage of new assertions :

``` html
<div id="test" data-options='{"name":"John"}'  data-foo="bar" />
```

``` javascript
expect($el).to.have.$data("foo","bar");
expect($el).to.have.$data("options").and.to.have.property("name","John");
```
